### PR TITLE
Router route APIs

### DIFF
--- a/pkg/client/api.go
+++ b/pkg/client/api.go
@@ -49,7 +49,7 @@ func (a *api) do(ctx context.Context, request interface{}, queryParams map[strin
 	if a.path == "" || a.method == "" || a.client == nil || a.jsonParser == nil {
 		panic("api not properly configured")
 	}
-
+	a.path = a.client.getHost() + "/" + consts.VmaasCmpAPIBasePath + "/" + a.path
 	for _, validations := range a.validations {
 		err := validations()
 		if err != nil {

--- a/pkg/client/api.go
+++ b/pkg/client/api.go
@@ -49,7 +49,7 @@ func (a *api) do(ctx context.Context, request interface{}, queryParams map[strin
 	if a.path == "" || a.method == "" || a.client == nil || a.jsonParser == nil {
 		panic("api not properly configured")
 	}
-	a.path = a.client.getHost() + "/" + consts.VmaasCmpAPIBasePath + "/" + a.path
+	a.path = fmt.Sprintf("%s/%s/%s", a.client.getHost(), consts.VmaasCmpAPIBasePath, a.path)
 	for _, validations := range a.validations {
 		err := validations()
 		if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -68,6 +68,7 @@ func NewAPIClient(cfg *Configuration) *APIClient {
 func (c *APIClient) getHost() string {
 	return c.cfg.Host
 }
+
 func (c *APIClient) SetMeta(meta interface{}, fn SetScmClientToken) error {
 	c.meta = meta
 	c.tokenFunc = fn

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -35,6 +35,7 @@ type APIClientHandler interface {
 	callAPI(request *http.Request) (*http.Response, error)
 	SetMeta(meta interface{}, fn SetScmClientToken) error
 	getVersion() int
+	getHost() string
 }
 
 // APIClient manages communication with the GreenLake Private Cloud VMaaS CMP API API v1.0.0
@@ -64,6 +65,9 @@ func NewAPIClient(cfg *Configuration) *APIClient {
 	return c
 }
 
+func (c *APIClient) getHost() string {
+	return c.cfg.Host
+}
 func (c *APIClient) SetMeta(meta interface{}, fn SetScmClientToken) error {
 	c.meta = meta
 	c.tokenFunc = fn

--- a/pkg/client/clouds.go
+++ b/pkg/client/clouds.go
@@ -32,7 +32,7 @@ func (a *CloudsAPIService) GetAllCloudDataStores(ctx context.Context, cloudID in
 
 	allCloudDSAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s/%d/%s", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%d/%s",
 			consts.ZonePath, cloudID, consts.DatstorePath),
 		client: a.Client,
 
@@ -69,7 +69,7 @@ func (a *CloudsAPIService) GetAllCloudResourcePools(ctx context.Context, cloudID
 
 	allCloudRPoolAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s/%d/resource-pools", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%d/resource-pools",
 			consts.ZonePath, cloudID),
 		client: a.Client,
 
@@ -105,8 +105,7 @@ func (a *CloudsAPIService) GetAllClouds(ctx context.Context,
 
 	allCloudAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
-			consts.ZonePath),
+		path:   consts.ZonePath,
 		client: a.Client,
 
 		jsonParser: func(body []byte) error {
@@ -124,7 +123,7 @@ func (a *CloudsAPIService) GetAllCloudNetworks(ctx context.Context, cloudID,
 
 	allCloudNetworkAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s/%s", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%s",
 			consts.OptionsPath, consts.ZoneNetworkOptionsPath),
 		client: a.Client,
 
@@ -150,8 +149,8 @@ func (a *CloudsAPIService) GetAllCloudFolders(
 
 	folderAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s/%d/%s",
-			a.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.ZonePath, cloudID, consts.FolderPath),
+		path: fmt.Sprintf("%s/%d/%s",
+			consts.ZonePath, cloudID, consts.FolderPath),
 		client: a.Client,
 		// jsonParser also stores folder response, since folders is not a local variable
 		jsonParser: func(body []byte) error {
@@ -183,8 +182,8 @@ func (a *CloudsAPIService) GetSpecificCloudFolder(
 
 	folderAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s/%d/%s/%d",
-			a.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.ZonePath, cloudID, consts.FolderPath, folderID),
+		path: fmt.Sprintf("%s/%d/%s/%d",
+			consts.ZonePath, cloudID, consts.FolderPath, folderID),
 		client: a.Client,
 
 		jsonParser: func(body []byte) error {

--- a/pkg/client/clouds_test.go
+++ b/pkg/client/clouds_test.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"testing"
 
+	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	"github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
 	"github.com/golang/mock/gomock"
 )
@@ -38,7 +39,8 @@ func TestCloudsAPIService_GetAllCloudDataStores(t *testing.T) {
 			},
 			cloudID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/zones/1/data-stores"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/zones/1/data-stores"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -79,7 +81,8 @@ func TestCloudsAPIService_GetAllCloudDataStores(t *testing.T) {
 			},
 			cloudID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/zones/1/data-stores"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/zones/1/data-stores"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -98,7 +101,8 @@ func TestCloudsAPIService_GetAllCloudDataStores(t *testing.T) {
 			},
 			cloudID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/zones/1/data-stores"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/zones/1/data-stores"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -132,6 +136,7 @@ func TestCloudsAPIService_GetAllCloudDataStores(t *testing.T) {
 			},
 			cloudID: 0,
 			given: func(m *MockAPIClientHandler) {
+				m.EXPECT().getHost().Return(mockHost)
 				m.EXPECT().getVersion().Return(999999)
 			},
 			want:    models.DataStoresResp{},
@@ -180,7 +185,8 @@ func TestCloudsAPIService_GetAllCloudResourcePools(t *testing.T) {
 			},
 			cloudID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/zones/1/resource-pools"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/zones/1/resource-pools"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -220,7 +226,8 @@ func TestCloudsAPIService_GetAllCloudResourcePools(t *testing.T) {
 			},
 			cloudID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/zones/1/resource-pools"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/zones/1/resource-pools"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -239,7 +246,8 @@ func TestCloudsAPIService_GetAllCloudResourcePools(t *testing.T) {
 			},
 			cloudID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/zones/1/resource-pools"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/zones/1/resource-pools"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -272,6 +280,7 @@ func TestCloudsAPIService_GetAllCloudResourcePools(t *testing.T) {
 			},
 			cloudID: 0,
 			given: func(m *MockAPIClientHandler) {
+				m.EXPECT().getHost().Return(mockHost)
 				m.EXPECT().getVersion().Return(999999)
 			},
 			want:    models.ResourcePoolsResp{},
@@ -318,7 +327,8 @@ func TestCloudsAPIService_GetAllClouds(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/zones"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/zones"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -357,7 +367,8 @@ func TestCloudsAPIService_GetAllClouds(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/zones"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/zones"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -375,7 +386,8 @@ func TestCloudsAPIService_GetAllClouds(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/zones"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/zones"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -445,7 +457,8 @@ func TestCloudsAPIService_GetAllCloudFolders(t *testing.T) {
 			},
 			cloudID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/zones/1/folders"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/zones/1/folders"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -485,7 +498,8 @@ func TestCloudsAPIService_GetAllCloudFolders(t *testing.T) {
 			},
 			cloudID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/zones/1/folders"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/zones/1/folders"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -504,7 +518,8 @@ func TestCloudsAPIService_GetAllCloudFolders(t *testing.T) {
 			},
 			cloudID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/zones/1/folders"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/zones/1/folders"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -571,7 +586,8 @@ func TestCloudsAPIService_GetAllCloudNetworks(t *testing.T) {
 			cloudID:         1,
 			provisionTypeID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/options/zoneNetworkOptions"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/options/zoneNetworkOptions"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -614,7 +630,8 @@ func TestCloudsAPIService_GetAllCloudNetworks(t *testing.T) {
 			cloudID:         1,
 			provisionTypeID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/options/zoneNetworkOptions"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/options/zoneNetworkOptions"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -632,7 +649,8 @@ func TestCloudsAPIService_GetAllCloudNetworks(t *testing.T) {
 			cloudID:         1,
 			provisionTypeID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/options/zoneNetworkOptions"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/options/zoneNetworkOptions"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -701,7 +719,8 @@ func TestCloudsAPIService_GetSpecificCloudFolder(t *testing.T) {
 			cloudID:  1,
 			folderID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/zones/1/folders/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/zones/1/folders/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -735,7 +754,8 @@ func TestCloudsAPIService_GetSpecificCloudFolder(t *testing.T) {
 			cloudID:  1,
 			folderID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/zones/1/folders/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/zones/1/folders/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -750,7 +770,8 @@ func TestCloudsAPIService_GetSpecificCloudFolder(t *testing.T) {
 			cloudID:  1,
 			folderID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/zones/1/folders/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/zones/1/folders/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -779,6 +800,7 @@ func TestCloudsAPIService_GetSpecificCloudFolder(t *testing.T) {
 			cloudID:  0,
 			folderID: 1,
 			given: func(m *MockAPIClientHandler) {
+				m.EXPECT().getHost().Return(mockHost)
 				m.EXPECT().getVersion().Return(999999)
 			},
 			want:    models.GetSpecificCloudFolder{},

--- a/pkg/client/domain.go
+++ b/pkg/client/domain.go
@@ -23,8 +23,8 @@ func (d *DomainAPIService) GetAllDomains(
 	var domainResp models.GetAllDomains
 	networkAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s/%s",
-			d.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworksPath, consts.DomainPath),
+		path: fmt.Sprintf("%s/%s",
+			consts.NetworksPath, consts.DomainPath),
 		client: d.Client,
 
 		jsonParser: func(body []byte) error {
@@ -43,8 +43,8 @@ func (d *DomainAPIService) GetSpecificDomain(
 	var domainResp models.GetSpecificDomain
 	networkAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s/%s/%d",
-			d.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworksPath, consts.DomainPath, domainID),
+		path: fmt.Sprintf("%s/%s/%d",
+			consts.NetworksPath, consts.DomainPath, domainID),
 		client: d.Client,
 
 		jsonParser: func(body []byte) error {

--- a/pkg/client/domain_test.go
+++ b/pkg/client/domain_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"testing"
 
+	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	"github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -35,7 +36,8 @@ func TestDomainAPIService_GetAllDomains(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/domains"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/domains"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -74,7 +76,8 @@ func TestDomainAPIService_GetAllDomains(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/domains"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/domains"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -92,7 +95,8 @@ func TestDomainAPIService_GetAllDomains(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/domains"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/domains"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -159,7 +163,8 @@ func TestDomainAPIService_GetSpecificDomain(t *testing.T) {
 			name:     "Normal Test case 1: Get a specific domain",
 			domainID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/domains/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/domains/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -192,7 +197,8 @@ func TestDomainAPIService_GetSpecificDomain(t *testing.T) {
 			name:     "Failed Test case 2: error in prepare request",
 			domainID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/domains/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/domains/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -206,7 +212,8 @@ func TestDomainAPIService_GetSpecificDomain(t *testing.T) {
 			name:     "Failed Test case 3: error in callAPI",
 			domainID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/domains/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/domains/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)

--- a/pkg/client/environment.go
+++ b/pkg/client/environment.go
@@ -5,7 +5,6 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	models "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
@@ -22,8 +21,7 @@ func (e *EnvironmentAPIService) GetAllEnvironment(ctx context.Context,
 
 	allEnvAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s", e.Cfg.Host, consts.VmaasCmpAPIBasePath,
-			consts.EnvironmentPath),
+		path:   consts.EnvironmentPath,
 		client: e.Client,
 
 		jsonParser: func(body []byte) error {

--- a/pkg/client/environment_test.go
+++ b/pkg/client/environment_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"testing"
 
+	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	models "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -36,7 +37,8 @@ func TestEnvironmentAPIService_GetAllEnvironment(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/environments"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/environments"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -74,7 +76,8 @@ func TestEnvironmentAPIService_GetAllEnvironment(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/environments"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/environments"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -92,7 +95,8 @@ func TestEnvironmentAPIService_GetAllEnvironment(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/environments"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/environments"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)

--- a/pkg/client/groups.go
+++ b/pkg/client/groups.go
@@ -31,7 +31,7 @@ func (a *GroupsAPIService) GetASpecificGroup(ctx context.Context,
 
 	specificGrpRespAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s/%d", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%d",
 			consts.GroupsPath, groupID),
 		client: a.Client,
 
@@ -67,8 +67,7 @@ func (a *GroupsAPIService) GetAllGroups(ctx context.Context,
 
 	allGrpRespAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
-			consts.GroupsPath),
+		path:   consts.GroupsPath,
 		client: a.Client,
 
 		jsonParser: func(body []byte) error {

--- a/pkg/client/groups_test.go
+++ b/pkg/client/groups_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"testing"
 
+	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	"github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -34,7 +35,8 @@ func TestGroupsAPIService_GetASpecificGroup(t *testing.T) {
 			name:    "Normal Test case 1: Get a specific group",
 			groupID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/groups/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/groups/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -67,7 +69,8 @@ func TestGroupsAPIService_GetASpecificGroup(t *testing.T) {
 			name:    "Failed Test case 2: Error in prepare requst",
 			groupID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/groups/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/groups/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -81,7 +84,8 @@ func TestGroupsAPIService_GetASpecificGroup(t *testing.T) {
 			name:    "Failed Test case 3: Error in callAPI",
 			groupID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/groups/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/groups/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -149,7 +153,8 @@ func TestGroupsAPIService_GetAllGroups(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/groups"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/groups"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -188,7 +193,8 @@ func TestGroupsAPIService_GetAllGroups(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/groups"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/groups"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -206,7 +212,8 @@ func TestGroupsAPIService_GetAllGroups(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/groups"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/groups"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)

--- a/pkg/client/helper.go
+++ b/pkg/client/helper.go
@@ -94,42 +94,6 @@ func parseVersion(version string) (int, error) {
 	return sum, nil
 }
 
-// selectHeaderContentType select a content type from the available list.
-func selectHeaderContentType(contentTypes []string) string {
-	if len(contentTypes) == 0 {
-		return ""
-	}
-	if contains(contentTypes, "application/json") {
-		return "application/json"
-	}
-
-	return contentTypes[0] // use the first content type specified in 'consumes'
-}
-
-// selectHeaderAccept join all accept types and return
-func selectHeaderAccept(accepts []string) string {
-	if len(accepts) == 0 {
-		return ""
-	}
-
-	if contains(accepts, "application/json") {
-		return "application/json"
-	}
-
-	return strings.Join(accepts, ",")
-}
-
-// contains is a case insenstive match, finding needle in a haystack
-func contains(haystack []string, needle string) bool {
-	for _, a := range haystack {
-		if strings.EqualFold(a, needle) {
-			return true
-		}
-	}
-
-	return false
-}
-
 // Add a file to the multipart request
 func addFile(w *multipart.Writer, fieldName, path string) error {
 	file, err := os.Open(path)

--- a/pkg/client/instances.go
+++ b/pkg/client/instances.go
@@ -6,10 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"net/url"
-	"strings"
 
 	"github.com/antihax/optional"
 
@@ -55,8 +51,7 @@ func (a *InstancesAPIService) CreateAnInstance(ctx context.Context,
 
 	createInstanceAPI := &api{
 		method: "POST",
-		path: fmt.Sprintf("%s/%s/%s", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
-			consts.InstancesPath),
+		path:   consts.InstancesPath,
 		client: a.Client,
 
 		jsonParser: func(body []byte) error {
@@ -91,7 +86,7 @@ func (a *InstancesAPIService) DeleteAnInstance(ctx context.Context,
 
 	delInstanceAPI := &api{
 		method: "DELETE",
-		path: fmt.Sprintf("%s/%s/%s/%d", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%d",
 			consts.InstancesPath, instanceID),
 		client: a.Client,
 
@@ -119,7 +114,7 @@ func (a *InstancesAPIService) GetASpecificInstance(ctx context.Context,
 
 	specificInstanceAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s/%d", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%d",
 			consts.InstancesPath, instanceID),
 		client: a.Client,
 
@@ -171,8 +166,7 @@ func (a *InstancesAPIService) GetAllInstances(ctx context.Context,
 
 	instanceAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
-			consts.InstancesPath),
+		path:   consts.InstancesPath,
 		client: a.Client,
 
 		jsonParser: func(body []byte) error {
@@ -199,7 +193,7 @@ func (a *InstancesAPIService) GetListOfSnapshotsForAnInstance(ctx context.Contex
 
 	listSnapshotAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s/%d/snapshots", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%d/snapshots",
 			consts.InstancesPath, instanceID),
 		client: a.Client,
 
@@ -231,7 +225,7 @@ func (a *InstancesAPIService) ImportSnapshotOfAnInstance(ctx context.Context, in
 
 	importSnapshotAPI := &api{
 		method: "PUT",
-		path: fmt.Sprintf("%s/%s/%s/%d/import-snapshot", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%d/import-snapshot",
 			consts.InstancesPath, instanceID),
 		client: a.Client,
 
@@ -259,7 +253,7 @@ func (a *InstancesAPIService) RestartAnInstance(ctx context.Context,
 
 	restartInstAPI := &api{
 		method: "PUT",
-		path: fmt.Sprintf("%s/%s/%s/%d/restart", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%d/restart",
 			consts.InstancesPath, instanceID),
 		client: a.Client,
 
@@ -290,7 +284,7 @@ func (a *InstancesAPIService) SnapshotAnInstance(ctx context.Context, instanceID
 
 	instanceAPI := &api{
 		method: "PUT",
-		path: fmt.Sprintf("%s/%s/%s/%d/snapshot", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%d/snapshot",
 			consts.InstancesPath, instanceID),
 		client: a.Client,
 
@@ -318,7 +312,7 @@ func (a *InstancesAPIService) StartAnInstance(ctx context.Context,
 
 	startInstanceAPI := &api{
 		method: "PUT",
-		path: fmt.Sprintf("%s/%s/%s/%d/start", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%d/start",
 			consts.InstancesPath, instanceID),
 		client: a.Client,
 
@@ -346,7 +340,7 @@ func (a *InstancesAPIService) StopAnInstance(ctx context.Context,
 
 	stopInstanceAPI := &api{
 		method: "PUT",
-		path: fmt.Sprintf("%s/%s/%s/%d/stop", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%d/stop",
 			consts.InstancesPath, instanceID),
 		client: a.Client,
 
@@ -373,7 +367,7 @@ func (a *InstancesAPIService) SuspendAnInstance(ctx context.Context,
 	suspendResp := models.InstancePowerResponse{}
 	suspendInstanceAPI := &api{
 		method: "PUT",
-		path: fmt.Sprintf("%s/%s/%s/%d/suspend", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%d/suspend",
 			consts.InstancesPath, instanceID),
 		client: a.Client,
 
@@ -386,103 +380,13 @@ func (a *InstancesAPIService) SuspendAnInstance(ctx context.Context,
 	return suspendResp, err
 }
 
-/*
-InstancesAPIService
-Undo the delete of an instance that is in pending removal state
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc.
- 	Passed from http.Request or context.Background().
- * @param serviceInstanceID
- * @param instanceID
-@return models.GetInstanceResponse
-*/
-func (a *InstancesAPIService) UndoDeleteOfAnInstance(ctx context.Context,
-	instanceID int) (models.GetInstanceResponse,
-	*http.Response, error) {
-	var (
-		localVarHTTPMethod  = strings.ToUpper("Put")
-		localVarPostBody    interface{}
-		localVarFileName    string
-		localVarFileBytes   []byte
-		localVarReturnValue models.GetInstanceResponse
-	)
-
-	// create path and map variables
-	localVarPath := fmt.Sprintf("%s/%s/%s/%d/cancel-removal", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
-		consts.InstancesPath, instanceID)
-
-	localVarHeaderParams := make(map[string]string)
-	localVarQueryParams := url.Values{}
-	localVarFormParams := url.Values{}
-
-	// to determine the Content-Type header
-	localVarHTTPContentTypes := []string{}
-
-	// set Content-Type header
-	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
-	if localVarHTTPContentType != "" {
-		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
-	}
-
-	// to determine the Accept header
-	localVarHTTPHeaderAccepts := []string{"application/json"}
-
-	// set Accept header
-	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
-	if localVarHTTPHeaderAccept != "" {
-		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-
-	r, err := a.Client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody,
-		localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
-	if err != nil {
-		return localVarReturnValue, nil, err
-	}
-
-	localVarHTTPResponse, err := a.Client.callAPI(r)
-	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-	if localVarHTTPResponse.StatusCode >= 300 {
-		return localVarReturnValue, localVarHTTPResponse, ParseError(localVarHTTPResponse)
-	}
-
-	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-
-	if localVarHTTPResponse.StatusCode < 300 {
-		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.Client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-		if err == nil {
-			return localVarReturnValue, localVarHTTPResponse, err
-		}
-	}
-
-	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-/*
-InstancesAPIService
-It is possible to resize VMs within an instance by increasing their memory plan or storage limit.
-This is done by assigning a new service plan to the VM.
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc.
- 	Passed from http.Request or context.Background().
- * @param serviceInstanceID
- * @param instanceID
- * @param optional nil or *InstancesAPIResizeAnInstanceOpts - Optional Parameters:
-     * @param "Body" (optional.Interface of ResizeInstanceBody) -
-@return models.GetInstanceResponse
-*/
-
 func (a *InstancesAPIService) ResizeAnInstance(ctx context.Context, instanceID int,
 	request *models.ResizeInstanceBody) (models.ResizeInstanceResponse, error) {
 	resizeResp := models.ResizeInstanceResponse{}
 
 	instanceAPI := &api{
 		method: "PUT",
-		path: fmt.Sprintf("%s/%s/%s/%d/resize", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%d/resize",
 			consts.InstancesPath, instanceID),
 		client: a.Client,
 
@@ -504,7 +408,7 @@ func (a *InstancesAPIService) UpdatingAnInstance(
 
 	instanceAPI := &api{
 		method: "PUT",
-		path: fmt.Sprintf("%s/%s/%s/%d", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%d",
 			consts.InstancesPath, instanceID),
 		client: a.Client,
 
@@ -523,7 +427,7 @@ func (a *InstancesAPIService) GetInstanceHistory(
 
 	historyAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s/%d/history", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%d/history",
 			consts.InstancesPath, instanceID),
 		client: a.Client,
 
@@ -541,7 +445,7 @@ func (a *InstancesAPIService) CloneAnInstance(ctx context.Context, instanceID in
 	var cloneResp models.SuccessOrErrorMessage
 	instanceClone := &api{
 		method: "PUT",
-		path: fmt.Sprintf("%s/%s/%s/%d/clone", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%d/clone",
 			consts.InstancesPath, instanceID),
 		client: a.Client,
 

--- a/pkg/client/instances_test.go
+++ b/pkg/client/instances_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"testing"
 
+	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	models "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -37,7 +38,8 @@ func TestInstancesAPIService_CloneAnInstance(t *testing.T) {
 			},
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/clone"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/clone"
 				method := "PUT"
 				// headers := getDefaultHeaders()
 				headers := getDefaultHeaders()
@@ -85,7 +87,8 @@ func TestInstancesAPIService_CloneAnInstance(t *testing.T) {
 			},
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/clone"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/clone"
 				method := "PUT"
 				// headers := getDefaultHeaders()
 				headers := getDefaultHeaders()
@@ -111,7 +114,8 @@ func TestInstancesAPIService_CloneAnInstance(t *testing.T) {
 			},
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/clone"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/clone"
 				method := "PUT"
 				// headers := getDefaultHeaders()
 				headers := getDefaultHeaders()
@@ -194,7 +198,8 @@ func TestInstancesAPIService_CreateAnInstance(t *testing.T) {
 				CloneName: "Instance_Create",
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances"
 				method := "POST"
 				headers := getDefaultHeaders()
 				postBody := ioutil.NopCloser(bytes.NewReader([]byte(`
@@ -241,7 +246,8 @@ func TestInstancesAPIService_CreateAnInstance(t *testing.T) {
 				CloneName: "Instance_Create",
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances"
 				method := "POST"
 				headers := getDefaultHeaders()
 				// mock the context only since it is not validated in this function
@@ -263,7 +269,8 @@ func TestInstancesAPIService_CreateAnInstance(t *testing.T) {
 				CloneName: "Instance_Create",
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances"
 				method := "POST"
 				headers := getDefaultHeaders()
 				postBody := ioutil.NopCloser(bytes.NewReader([]byte(`
@@ -336,7 +343,8 @@ func TestInstancesAPIService_DeleteAnInstance(t *testing.T) {
 			name:       "Normal Test case 1: Delete an Instance",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1"
 				method := "DELETE"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -365,7 +373,8 @@ func TestInstancesAPIService_DeleteAnInstance(t *testing.T) {
 			name:       "Failed test case 2: Error in call prepare request",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1"
 				method := "DELETE"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -379,7 +388,8 @@ func TestInstancesAPIService_DeleteAnInstance(t *testing.T) {
 			name:       "Failed test case 3: error in callAPI",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1"
 				method := "DELETE"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -445,7 +455,8 @@ func TestInstancesAPIService_ImportSnapshotOfAnInstance(t *testing.T) {
 				StorageProviderID: 1,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/import-snapshot"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/import-snapshot"
 				method := "PUT"
 				headers := getDefaultHeaders()
 				postBody := ioutil.NopCloser(bytes.NewReader([]byte(`{
@@ -482,7 +493,8 @@ func TestInstancesAPIService_ImportSnapshotOfAnInstance(t *testing.T) {
 				StorageProviderID: 1,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/import-snapshot"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/import-snapshot"
 				method := "PUT"
 				headers := getDefaultHeaders()
 				pBody := &models.ImportSnapshotBody{
@@ -502,7 +514,8 @@ func TestInstancesAPIService_ImportSnapshotOfAnInstance(t *testing.T) {
 				StorageProviderID: 1,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/import-snapshot"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/import-snapshot"
 				method := "PUT"
 				headers := getDefaultHeaders()
 				postBody := ioutil.NopCloser(bytes.NewReader([]byte(`{
@@ -582,7 +595,8 @@ func TestInstancesAPIService_ResizeAnInstance(t *testing.T) {
 				DeleteOriginalVolumes: false,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/resize"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/resize"
 				method := "PUT"
 				postBody := ioutil.NopCloser(bytes.NewReader([]byte(`
 				{
@@ -637,7 +651,8 @@ func TestInstancesAPIService_ResizeAnInstance(t *testing.T) {
 				DeleteOriginalVolumes: false,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/resize"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/resize"
 				method := "PUT"
 				pBody := &models.ResizeInstanceBody{
 					Instance: &models.ResizeInstanceBodyInstance{
@@ -670,7 +685,8 @@ func TestInstancesAPIService_ResizeAnInstance(t *testing.T) {
 				DeleteOriginalVolumes: false,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/resize"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/resize"
 				method := "PUT"
 				postBody := ioutil.NopCloser(bytes.NewReader([]byte(`
 				{
@@ -753,7 +769,8 @@ func TestInstancesAPIService_SnapshotAnInstance(t *testing.T) {
 				},
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/snapshot"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/snapshot"
 				method := "PUT"
 				headers := getDefaultHeaders()
 				postBody := ioutil.NopCloser(bytes.NewReader([]byte(`
@@ -804,7 +821,8 @@ func TestInstancesAPIService_SnapshotAnInstance(t *testing.T) {
 				},
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/snapshot"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/snapshot"
 				method := "PUT"
 				headers := getDefaultHeaders()
 				pBody := &models.SnapshotBody{
@@ -830,7 +848,8 @@ func TestInstancesAPIService_SnapshotAnInstance(t *testing.T) {
 				},
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/snapshot"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/snapshot"
 				method := "PUT"
 				headers := getDefaultHeaders()
 				postBody := ioutil.NopCloser(bytes.NewReader([]byte(`
@@ -912,7 +931,8 @@ func TestInstancesAPIService_UpdatingAnInstance(t *testing.T) {
 				},
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1"
 				method := "PUT"
 				postBody := ioutil.NopCloser(bytes.NewReader([]byte(`
 				{
@@ -960,7 +980,8 @@ func TestInstancesAPIService_UpdatingAnInstance(t *testing.T) {
 				},
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1"
 				method := "PUT"
 
 				pBody := &models.UpdateInstanceBody{
@@ -986,7 +1007,8 @@ func TestInstancesAPIService_UpdatingAnInstance(t *testing.T) {
 				},
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1"
 				method := "PUT"
 				postBody := ioutil.NopCloser(bytes.NewReader([]byte(`
 				{
@@ -1060,7 +1082,8 @@ func TestInstancesAPIService_GetASpecificInstance(t *testing.T) {
 			name:       "Normal Test case 1: Get a specific instance",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -1094,7 +1117,8 @@ func TestInstancesAPIService_GetASpecificInstance(t *testing.T) {
 			name:       "Failed test case 2: Error in call prepare request",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				// mock the context only since it is not validated in this function
@@ -1109,7 +1133,8 @@ func TestInstancesAPIService_GetASpecificInstance(t *testing.T) {
 			name:       "Failed test case 3: error in callAPI",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -1177,7 +1202,8 @@ func TestInstancesAPIService_GetAllInstances(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -1218,7 +1244,8 @@ func TestInstancesAPIService_GetAllInstances(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -1236,7 +1263,8 @@ func TestInstancesAPIService_GetAllInstances(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -1302,7 +1330,8 @@ func TestInstancesAPIService_GetListOfSnapshotsForAnInstance(t *testing.T) {
 			name:       "Normal Test case 1: Get list of snapshots for an instance",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/snapshots"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/snapshots"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -1337,7 +1366,8 @@ func TestInstancesAPIService_GetListOfSnapshotsForAnInstance(t *testing.T) {
 			name:       "Failed test case 2: Error in call prepare request",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/snapshots"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/snapshots"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -1351,7 +1381,8 @@ func TestInstancesAPIService_GetListOfSnapshotsForAnInstance(t *testing.T) {
 			name:       "Failed test case 3: error in callAPI",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/snapshots"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/snapshots"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -1415,7 +1446,8 @@ func TestInstancesAPIService_GetInstanceHistory(t *testing.T) {
 			name:       "Normal test case 1: Get all history",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/history"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/history"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -1466,7 +1498,8 @@ func TestInstancesAPIService_GetInstanceHistory(t *testing.T) {
 			name:       "Failed test case 2: Error in call prepare request",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/history"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/history"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -1480,7 +1513,8 @@ func TestInstancesAPIService_GetInstanceHistory(t *testing.T) {
 			name:       "Failed test case 3: error in callAPI",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/history"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/history"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -1545,7 +1579,8 @@ func TestInstancesAPIService_RestartAnInstance(t *testing.T) {
 			name:       "Normal Test case 1: Restart an Instance",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/restart"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/restart"
 				method := "PUT"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -1571,7 +1606,8 @@ func TestInstancesAPIService_RestartAnInstance(t *testing.T) {
 			name:       "Failed test case 2: Error in call prepare request",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/restart"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/restart"
 				method := "PUT"
 				headers := getDefaultHeaders()
 
@@ -1586,7 +1622,8 @@ func TestInstancesAPIService_RestartAnInstance(t *testing.T) {
 			name:       "Failed test case 3: error in callAPI",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/restart"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/restart"
 				method := "PUT"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -1648,7 +1685,8 @@ func TestInstancesAPIService_StartAnInstance(t *testing.T) {
 			name:       "Normal Test case 1: Start an Instance",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/start"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/start"
 				method := "PUT"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -1674,7 +1712,8 @@ func TestInstancesAPIService_StartAnInstance(t *testing.T) {
 			name:       "Failed test case 2: Error in call prepare request",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/start"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/start"
 				method := "PUT"
 				headers := getDefaultHeaders()
 
@@ -1689,7 +1728,8 @@ func TestInstancesAPIService_StartAnInstance(t *testing.T) {
 			name:       "Failed test case 3: error in callAPI",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/start"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/start"
 				method := "PUT"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -1751,7 +1791,8 @@ func TestInstancesAPIService_StopAnInstance(t *testing.T) {
 			name:       "Normal Test case 1: Stop an Instance",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/stop"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/stop"
 				method := "PUT"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -1777,7 +1818,8 @@ func TestInstancesAPIService_StopAnInstance(t *testing.T) {
 			name:       "Failed test case 2: Error in call prepare request",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/stop"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/stop"
 				method := "PUT"
 				headers := getDefaultHeaders()
 
@@ -1792,7 +1834,8 @@ func TestInstancesAPIService_StopAnInstance(t *testing.T) {
 			name:       "Failed test case 3: error in callAPI",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/stop"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/stop"
 				method := "PUT"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -1854,7 +1897,8 @@ func TestInstancesAPIService_SuspendAnInstance(t *testing.T) {
 			name:       "Normal Test case 1: Suspend an Instance",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/suspend"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/suspend"
 				method := "PUT"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -1880,7 +1924,8 @@ func TestInstancesAPIService_SuspendAnInstance(t *testing.T) {
 			name:       "Failed test case 2: Error in call prepare request",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/suspend"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/suspend"
 				method := "PUT"
 				headers := getDefaultHeaders()
 
@@ -1895,7 +1940,8 @@ func TestInstancesAPIService_SuspendAnInstance(t *testing.T) {
 			name:       "Failed test case 3: error in callAPI",
 			instanceID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/instances/1/suspend"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/instances/1/suspend"
 				method := "PUT"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)

--- a/pkg/client/library.go
+++ b/pkg/client/library.go
@@ -5,7 +5,6 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	"github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
@@ -30,8 +29,7 @@ func (a *LibraryAPIService) GetAllLayouts(ctx context.Context,
 
 	allLayoutsAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
-			consts.LibraryLayoutPath),
+		path:   consts.LibraryLayoutPath,
 		client: a.Client,
 
 		jsonParser: func(body []byte) error {
@@ -49,8 +47,7 @@ func (a *LibraryAPIService) GetAllInstanceTypes(ctx context.Context,
 
 	allInstTypeAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
-			consts.LibraryInstanceTypesPath),
+		path:   consts.LibraryInstanceTypesPath,
 		client: a.Client,
 
 		jsonParser: func(body []byte) error {

--- a/pkg/client/library_test.go
+++ b/pkg/client/library_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"testing"
 
+	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	"github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -36,7 +37,8 @@ func TestLibraryAPIService_GetAllLayouts(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/library/layouts"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/library/layouts"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -76,7 +78,8 @@ func TestLibraryAPIService_GetAllLayouts(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/library/layouts"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/library/layouts"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -94,7 +97,8 @@ func TestLibraryAPIService_GetAllLayouts(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/library/layouts"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/library/layouts"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -165,7 +169,8 @@ func TestLibraryAPIService_GetAllInstanceTypes(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/library/instance-types"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/library/instance-types"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -204,7 +209,8 @@ func TestLibraryAPIService_GetAllInstanceTypes(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/library/instance-types"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/library/instance-types"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -222,7 +228,8 @@ func TestLibraryAPIService_GetAllInstanceTypes(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/library/instance-types"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/library/instance-types"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)

--- a/pkg/client/networks.go
+++ b/pkg/client/networks.go
@@ -25,7 +25,7 @@ func (n *NetworksAPIService) GetAllNetworks(
 	var networksResp models.ListNetworksBody
 	networkAPI := &api{
 		method: "GET",
-		path:   fmt.Sprintf("%s/%s/%s", n.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworksPath),
+		path:   consts.NetworksPath,
 		client: n.Client,
 
 		jsonParser: func(body []byte) error {
@@ -44,7 +44,7 @@ func (n *NetworksAPIService) GetSpecificNetwork(
 	var networksResp models.GetSpecificNetworkBody
 	networkAPI := &api{
 		method: "GET",
-		path:   fmt.Sprintf("%s/%s/%s/%d", n.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworksPath, networkID),
+		path:   fmt.Sprintf("%s/%d", consts.NetworksPath, networkID),
 		client: n.Client,
 
 		jsonParser: func(body []byte) error {
@@ -64,7 +64,7 @@ func (n *NetworksAPIService) CreateNetwork(
 	networkAPI := &api{
 		compatibleVersion: networkCompatibleVersion,
 		method:            "POST",
-		path:              fmt.Sprintf("%s/%s/%s", n.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworksPath),
+		path:              consts.NetworksPath,
 		client:            n.Client,
 
 		jsonParser: func(body []byte) error {
@@ -84,7 +84,7 @@ func (n *NetworksAPIService) DeleteNetwork(
 	networkAPI := &api{
 		compatibleVersion: networkCompatibleVersion,
 		method:            "DELETE",
-		path:              fmt.Sprintf("%s/%s/%s/%d", n.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworksPath, networkID),
+		path:              fmt.Sprintf("%s/%d", consts.NetworksPath, networkID),
 		client:            n.Client,
 
 		jsonParser: func(body []byte) error {
@@ -104,7 +104,7 @@ func (n *NetworksAPIService) GetNetworkType(
 	networkAPI := &api{
 		compatibleVersion: networkCompatibleVersion,
 		method:            "GET",
-		path:              fmt.Sprintf("%s/%s/%s", n.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworkTypePath),
+		path:              consts.NetworkTypePath,
 		client:            n.Client,
 
 		jsonParser: func(body []byte) error {
@@ -123,7 +123,7 @@ func (n *NetworksAPIService) GetNetworkPool(
 	var resp models.GetNetworkPoolsResp
 	networkAPI := &api{
 		method: "GET",
-		path:   fmt.Sprintf("%s/%s/%s/%s", n.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworksPath, consts.NetworkPoolPath),
+		path:   fmt.Sprintf("%s/%s", consts.NetworksPath, consts.NetworkPoolPath),
 		client: n.Client,
 
 		jsonParser: func(body []byte) error {
@@ -142,8 +142,8 @@ func (n *NetworksAPIService) GetSpecificNetworkPool(
 	var resp models.GetSpecificNetworkPool
 	networkAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s/%s/%d",
-			n.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworksPath, consts.NetworkPoolPath, networkPoolID),
+		path: fmt.Sprintf("%s/%s/%d",
+			consts.NetworksPath, consts.NetworkPoolPath, networkPoolID),
 		client: n.Client,
 
 		jsonParser: func(body []byte) error {
@@ -164,7 +164,7 @@ func (n *NetworksAPIService) UpdateNetwork(
 	networkAPI := &api{
 		compatibleVersion: networkCompatibleVersion,
 		method:            "PUT",
-		path:              fmt.Sprintf("%s/%s/%s/%d", n.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworksPath, networkID),
+		path:              fmt.Sprintf("%s/%d", consts.NetworksPath, networkID),
 		client:            n.Client,
 
 		jsonParser: func(body []byte) error {
@@ -183,7 +183,7 @@ func (n *NetworksAPIService) GetNetworkProxy(
 	var proxyResp models.GetAllNetworkProxies
 	networkAPI := &api{
 		method: "GET",
-		path:   fmt.Sprintf("%s/%s/%s/%s", n.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworksPath, consts.NetworkProxyPath),
+		path:   fmt.Sprintf("%s/%s", consts.NetworksPath, consts.NetworkProxyPath),
 		client: n.Client,
 
 		jsonParser: func(body []byte) error {

--- a/pkg/client/networks_test.go
+++ b/pkg/client/networks_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"testing"
 
+	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	"github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -36,7 +37,8 @@ func TestNetworksAPIService_GetAllNetworks(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -77,7 +79,8 @@ func TestNetworksAPIService_GetAllNetworks(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -95,7 +98,8 @@ func TestNetworksAPIService_GetAllNetworks(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -163,7 +167,8 @@ func TestNetworksAPIService_CreateNetwork(t *testing.T) {
 				},
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks"
 				method := "POST"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -249,7 +254,8 @@ func TestNetworksAPIService_UpdateNetwork(t *testing.T) {
 				},
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/1"
 				method := "PUT"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -316,7 +322,8 @@ func TestNetworksAPIService_GetNetworkProxy(t *testing.T) {
 				"name": "NSXT",
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/proxies"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/proxies"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -391,7 +398,8 @@ func TestNetworksAPIService_GetSpecificNetwork(t *testing.T) {
 			name:      "Normal Test case 1: Get specific network",
 			networkID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -424,7 +432,8 @@ func TestNetworksAPIService_GetSpecificNetwork(t *testing.T) {
 			name:      "Failed Test case 2: Error in prepare request",
 			networkID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -438,7 +447,8 @@ func TestNetworksAPIService_GetSpecificNetwork(t *testing.T) {
 			name:      "Failed Test case 3: Error in callAPI",
 			networkID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -503,7 +513,8 @@ func TestNetworksAPIService_DeleteNetwork(t *testing.T) {
 			name:      "Normal Test case 1: Delete a network",
 			networkID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/1"
 				method := "DELETE"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -532,7 +543,8 @@ func TestNetworksAPIService_DeleteNetwork(t *testing.T) {
 			name:      "Failed Test case 2: Error in prepare request",
 			networkID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/1"
 				method := "DELETE"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -546,7 +558,8 @@ func TestNetworksAPIService_DeleteNetwork(t *testing.T) {
 			name:      "Failed Test case 3: Error in callAPI",
 			networkID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/1"
 				method := "DELETE"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -614,7 +627,8 @@ func TestNetworksAPIService_GetNetworkType(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/network-types"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/network-types"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -653,7 +667,8 @@ func TestNetworksAPIService_GetNetworkType(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/network-types"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/network-types"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -671,7 +686,8 @@ func TestNetworksAPIService_GetNetworkType(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/network-types"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/network-types"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -741,7 +757,8 @@ func TestNetworksAPIService_GetNetworkPool(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/pools"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/pools"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -780,7 +797,8 @@ func TestNetworksAPIService_GetNetworkPool(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/pools"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/pools"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -798,7 +816,8 @@ func TestNetworksAPIService_GetNetworkPool(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/pools"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/pools"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -865,7 +884,8 @@ func TestNetworksAPIService_GetSpecificNetworkPool(t *testing.T) {
 			name:          "Normal Test case 1: Get specific network",
 			networkPoolID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/pools/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/pools/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -898,7 +918,8 @@ func TestNetworksAPIService_GetSpecificNetworkPool(t *testing.T) {
 			name:          "Failed Test case 2: Error in prepare request",
 			networkPoolID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/pools/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/pools/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -912,7 +933,8 @@ func TestNetworksAPIService_GetSpecificNetworkPool(t *testing.T) {
 			name:          "Failed Test case 3: Error in callAPI",
 			networkPoolID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/pools/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/pools/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)

--- a/pkg/client/plans.go
+++ b/pkg/client/plans.go
@@ -5,7 +5,6 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	"github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
@@ -16,22 +15,13 @@ type PlansAPIService struct {
 	Cfg    Configuration
 }
 
-/*
-PlansAPIService
-Get All Service Plans
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc.
- 	Passed from http.Request or context.Background().
- * @param serviceInstanceID
-
-*/
 func (a *PlansAPIService) GetAllServicePlans(ctx context.Context,
 	param map[string]string) (models.ServicePlans, error) {
 	response := models.ServicePlans{}
 
 	allServicePlansAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
-			consts.ServicePlansPath),
+		path:   consts.ServicePlansPath,
 		client: a.Client,
 
 		jsonParser: func(body []byte) error {

--- a/pkg/client/plans.go
+++ b/pkg/client/plans.go
@@ -15,6 +15,13 @@ type PlansAPIService struct {
 	Cfg    Configuration
 }
 
+/*
+PlansAPIService
+Get All Service Plans
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc.
+ 	Passed from http.Request or context.Background().
+ * @param serviceInstanceID
+*/
 func (a *PlansAPIService) GetAllServicePlans(ctx context.Context,
 	param map[string]string) (models.ServicePlans, error) {
 	response := models.ServicePlans{}

--- a/pkg/client/plans_test.go
+++ b/pkg/client/plans_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"testing"
 
+	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	"github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -36,7 +37,8 @@ func TestPlansAPIService_GetAllServicePlans(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/service-plans"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/service-plans"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -76,7 +78,8 @@ func TestPlansAPIService_GetAllServicePlans(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/service-plans"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/service-plans"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -94,7 +97,8 @@ func TestPlansAPIService_GetAllServicePlans(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/service-plans"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/service-plans"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)

--- a/pkg/client/power_schedule.go
+++ b/pkg/client/power_schedule.go
@@ -5,7 +5,6 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	models "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
@@ -31,8 +30,7 @@ func (a *PowerSchedulesAPIService) GetAllPowerSchedules(ctx context.Context,
 
 	allPowerScheduleAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
-			consts.PowerSchedulPath),
+		path:   consts.PowerSchedulPath,
 		client: a.Client,
 
 		jsonParser: func(body []byte) error {

--- a/pkg/client/power_schedule_test.go
+++ b/pkg/client/power_schedule_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"testing"
 
+	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	models "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -36,7 +37,8 @@ func TestPowerSchedulesAPIService_GetAllPowerSchedules(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/power-schedules"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/power-schedules"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -75,7 +77,8 @@ func TestPowerSchedulesAPIService_GetAllPowerSchedules(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/power-schedules"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/power-schedules"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -93,7 +96,8 @@ func TestPowerSchedulesAPIService_GetAllPowerSchedules(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/power-schedules"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/power-schedules"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)

--- a/pkg/client/provisioning.go
+++ b/pkg/client/provisioning.go
@@ -5,7 +5,6 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	models "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
@@ -22,8 +21,7 @@ func (a *ProvisioningAPIService) GetAllProvisioningTypes(ctx context.Context,
 
 	allProvisionAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
-			consts.ProvisionTypesPath),
+		path:   consts.ProvisionTypesPath,
 		client: a.Client,
 
 		jsonParser: func(body []byte) error {

--- a/pkg/client/provisioning_test.go
+++ b/pkg/client/provisioning_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"testing"
 
+	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	models "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -34,7 +35,8 @@ func TestProvisioningAPIService_GetAllProvisioningTypes(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/provision-types"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/provision-types"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -73,7 +75,8 @@ func TestProvisioningAPIService_GetAllProvisioningTypes(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/provision-types"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/provision-types"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -91,7 +94,8 @@ func TestProvisioningAPIService_GetAllProvisioningTypes(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/provision-types"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/provision-types"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)

--- a/pkg/client/router.go
+++ b/pkg/client/router.go
@@ -160,8 +160,8 @@ func (r *RouterAPIService) CreateRouterNat(
 	ctx context.Context,
 	routerID int,
 	request models.CreateRouterNatRequest,
-) (models.CreateRouterNatResponse, error) {
-	natResp := models.CreateRouterNatResponse{}
+) (models.SuccessOrErrorMessage, error) {
+	natResp := models.SuccessOrErrorMessage{}
 	routerAPI := &api{
 		compatibleVersion: routerCompatibleVersion,
 		method:            "POST",
@@ -201,8 +201,8 @@ func (r *RouterAPIService) UpdateRouterNat(
 	ctx context.Context,
 	routerID, natID int,
 	req models.CreateRouterNatRequest,
-) (models.CreateRouterNatResponse, error) {
-	natResp := models.CreateRouterNatResponse{}
+) (models.SuccessOrErrorMessage, error) {
+	natResp := models.SuccessOrErrorMessage{}
 	routerAPI := &api{
 		compatibleVersion: routerCompatibleVersion,
 		method:            "PUT",
@@ -242,8 +242,8 @@ func (r *RouterAPIService) CreateRouterFirewallRuleGroup(
 	ctx context.Context,
 	routerID int,
 	request models.CreateRouterFirewallRuleGroupRequest,
-) (models.CreateRouterFirewallRuleGroupResponse, error) {
-	firewallGroupResp := models.CreateRouterFirewallRuleGroupResponse{}
+) (models.SuccessOrErrorMessage, error) {
+	firewallGroupResp := models.SuccessOrErrorMessage{}
 	routerAPI := &api{
 		compatibleVersion: routerCompatibleVersion,
 		method:            "POST",
@@ -299,22 +299,63 @@ func (r *RouterAPIService) DeleteRouterFirewallRuleGroup(
 	return firewallGroupResp, err
 }
 
-func (r *RouterAPIService) CreateStaticRoute(
+func (r *RouterAPIService) CreateRouterRoute(
 	ctx context.Context,
 	routerID int,
+	req models.CreateRouterRoute,
 ) (models.SuccessOrErrorMessage, error) {
-	firewallGroupResp := models.SuccessOrErrorMessage{}
+	resp := models.SuccessOrErrorMessage{}
 	routerAPI := &api{
 		compatibleVersion: routerCompatibleVersion,
 		method:            "POST",
-		path: fmt.Sprintf("%s/%s/%d", consts.NetworksPath,
-			consts.NetworkRouterPath, routerID),
+		path: fmt.Sprintf("%s/%s/%d/%s", consts.NetworksPath,
+			consts.NetworkRouterPath, routerID, consts.RouterRoutePath),
 		client: r.Client,
 		jsonParser: func(body []byte) error {
-			return json.Unmarshal(body, &firewallGroupResp)
+			return json.Unmarshal(body, &resp)
+		},
+	}
+	err := routerAPI.do(ctx, req, nil)
+
+	return resp, err
+}
+
+func (r *RouterAPIService) GetSpecificRouterRoute(
+	ctx context.Context,
+	routerID, routeID int,
+) (models.GetSpecificRouterRoute, error) {
+	resp := models.GetSpecificRouterRoute{}
+	routerAPI := &api{
+		compatibleVersion: routerCompatibleVersion,
+		method:            "GET",
+		path: fmt.Sprintf("%s/%s/%d/%s/%d", consts.NetworksPath,
+			consts.NetworkRouterPath, routerID, consts.RouterRoutePath, routeID),
+		client: r.Client,
+		jsonParser: func(body []byte) error {
+			return json.Unmarshal(body, &resp)
 		},
 	}
 	err := routerAPI.do(ctx, nil, nil)
 
-	return firewallGroupResp, err
+	return resp, err
+}
+
+func (r *RouterAPIService) DeleteRouterRoute(
+	ctx context.Context,
+	routerID, routeID int,
+) (models.SuccessOrErrorMessage, error) {
+	resp := models.SuccessOrErrorMessage{}
+	routerAPI := &api{
+		compatibleVersion: routerCompatibleVersion,
+		method:            "DELETE",
+		path: fmt.Sprintf("%s/%s/%d/%s/%d", consts.NetworksPath,
+			consts.NetworkRouterPath, routerID, consts.RouterRoutePath, routeID),
+		client: r.Client,
+		jsonParser: func(body []byte) error {
+			return json.Unmarshal(body, &resp)
+		},
+	}
+	err := routerAPI.do(ctx, nil, nil)
+
+	return resp, err
 }

--- a/pkg/client/router.go
+++ b/pkg/client/router.go
@@ -306,7 +306,7 @@ func (r *RouterAPIService) CreateRouterRoute(
 ) (models.SuccessOrErrorMessage, error) {
 	resp := models.SuccessOrErrorMessage{}
 	routerAPI := &api{
-		compatibleVersion: routerCompatibleVersion,
+		compatibleVersion: "5.2.12",
 		method:            "POST",
 		path: fmt.Sprintf("%s/%s/%d/%s", consts.NetworksPath,
 			consts.NetworkRouterPath, routerID, consts.RouterRoutePath),
@@ -326,7 +326,7 @@ func (r *RouterAPIService) GetSpecificRouterRoute(
 ) (models.GetSpecificRouterRoute, error) {
 	resp := models.GetSpecificRouterRoute{}
 	routerAPI := &api{
-		compatibleVersion: routerCompatibleVersion,
+		compatibleVersion: "5.2.12",
 		method:            "GET",
 		path: fmt.Sprintf("%s/%s/%d/%s/%d", consts.NetworksPath,
 			consts.NetworkRouterPath, routerID, consts.RouterRoutePath, routeID),
@@ -346,7 +346,7 @@ func (r *RouterAPIService) DeleteRouterRoute(
 ) (models.SuccessOrErrorMessage, error) {
 	resp := models.SuccessOrErrorMessage{}
 	routerAPI := &api{
-		compatibleVersion: routerCompatibleVersion,
+		compatibleVersion: "5.2.12",
 		method:            "DELETE",
 		path: fmt.Sprintf("%s/%s/%d/%s/%d", consts.NetworksPath,
 			consts.NetworkRouterPath, routerID, consts.RouterRoutePath, routeID),

--- a/pkg/client/router.go
+++ b/pkg/client/router.go
@@ -26,9 +26,8 @@ func (r *RouterAPIService) GetAllRouter(
 	routerAPI := &api{
 		compatibleVersion: routerCompatibleVersion,
 		method:            "GET",
-		path: fmt.Sprintf("%s/%s/%s/%s", r.Cfg.Host, consts.VmaasCmpAPIBasePath,
-			consts.NetworksPath, consts.NetworkRouterPath),
-		client: r.Client,
+		path:              fmt.Sprintf("%s/%s", consts.NetworksPath, consts.NetworkRouterPath),
+		client:            r.Client,
 		jsonParser: func(body []byte) error {
 			return json.Unmarshal(body, &routerResp)
 		},
@@ -46,7 +45,7 @@ func (r *RouterAPIService) GetSpecificRouter(
 	routerAPI := &api{
 		compatibleVersion: routerCompatibleVersion,
 		method:            "GET",
-		path: fmt.Sprintf("%s/%s/%s/%s/%d", r.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%s/%d",
 			consts.NetworksPath, consts.NetworkRouterPath, routerID),
 		client: r.Client,
 		jsonParser: func(body []byte) error {
@@ -66,9 +65,8 @@ func (r *RouterAPIService) CreateRouter(
 	routerAPI := &api{
 		compatibleVersion: routerCompatibleVersion,
 		method:            "POST",
-		path: fmt.Sprintf("%s/%s/%s/%s", r.Cfg.Host, consts.VmaasCmpAPIBasePath,
-			consts.NetworksPath, consts.NetworkRouterPath),
-		client: r.Client,
+		path:              fmt.Sprintf("%s/%s", consts.NetworksPath, consts.NetworkRouterPath),
+		client:            r.Client,
 		jsonParser: func(body []byte) error {
 			return json.Unmarshal(body, &routerResp)
 		},
@@ -87,7 +85,7 @@ func (r *RouterAPIService) UpdateRouter(
 	routerAPI := &api{
 		compatibleVersion: routerCompatibleVersion,
 		method:            "PUT",
-		path: fmt.Sprintf("%s/%s/%s/%s/%d", r.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%s/%d",
 			consts.NetworksPath, consts.NetworkRouterPath, routerID),
 		client: r.Client,
 		jsonParser: func(body []byte) error {
@@ -107,7 +105,7 @@ func (r *RouterAPIService) DeleteRouter(
 	routerAPI := &api{
 		compatibleVersion: routerCompatibleVersion,
 		method:            "DELETE",
-		path: fmt.Sprintf("%s/%s/%s/%s/%d", r.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%s/%d",
 			consts.NetworksPath, consts.NetworkRouterPath, routerID),
 		client: r.Client,
 		jsonParser: func(body []byte) error {
@@ -127,9 +125,8 @@ func (r *RouterAPIService) GetRouterTypes(
 	routerAPI := &api{
 		compatibleVersion: routerCompatibleVersion,
 		method:            "GET",
-		path: fmt.Sprintf("%s/%s/%s", r.Cfg.Host, consts.VmaasCmpAPIBasePath,
-			consts.NetworkRouterTypePath),
-		client: r.Client,
+		path:              consts.NetworkRouterTypePath,
+		client:            r.Client,
 		jsonParser: func(body []byte) error {
 			return json.Unmarshal(body, &routerResp)
 		},
@@ -147,7 +144,7 @@ func (r *RouterAPIService) GetNetworkServices(
 	routerAPI := &api{
 		compatibleVersion: routerCompatibleVersion,
 		method:            "GET",
-		path: fmt.Sprintf("%s/%s/%s/%s", r.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworksPath,
+		path: fmt.Sprintf("%s/%s", consts.NetworksPath,
 			consts.NetworkServicePath),
 		client: r.Client,
 		jsonParser: func(body []byte) error {
@@ -168,7 +165,7 @@ func (r *RouterAPIService) CreateRouterNat(
 	routerAPI := &api{
 		compatibleVersion: routerCompatibleVersion,
 		method:            "POST",
-		path: fmt.Sprintf("%s/%s/%s/%s/%d/%s", r.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworksPath,
+		path: fmt.Sprintf("%s/%s/%d/%s", consts.NetworksPath,
 			consts.NetworkRouterPath, routerID, consts.RoutersNatPath),
 		client: r.Client,
 		jsonParser: func(body []byte) error {
@@ -188,8 +185,7 @@ func (r *RouterAPIService) GetSpecificRouterNat(
 	routerAPI := &api{
 		compatibleVersion: routerCompatibleVersion,
 		method:            "GET",
-		path: fmt.Sprintf("%s/%s/%s/%s/%d/%s/%d",
-			r.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworksPath,
+		path: fmt.Sprintf("%s/%s/%d/%s/%d", consts.NetworksPath,
 			consts.NetworkRouterPath, routerID, consts.RoutersNatPath, natID),
 		client: r.Client,
 		jsonParser: func(body []byte) error {
@@ -210,8 +206,7 @@ func (r *RouterAPIService) UpdateRouterNat(
 	routerAPI := &api{
 		compatibleVersion: routerCompatibleVersion,
 		method:            "PUT",
-		path: fmt.Sprintf("%s/%s/%s/%s/%d/%s/%d",
-			r.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworksPath,
+		path: fmt.Sprintf("%s/%s/%d/%s/%d", consts.NetworksPath,
 			consts.NetworkRouterPath, routerID, consts.RoutersNatPath, natID),
 		client: r.Client,
 		jsonParser: func(body []byte) error {
@@ -231,8 +226,7 @@ func (r *RouterAPIService) DeleteRouterNat(
 	routerAPI := &api{
 		compatibleVersion: routerCompatibleVersion,
 		method:            "DELETE",
-		path: fmt.Sprintf("%s/%s/%s/%s/%d/%s/%d",
-			r.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworksPath,
+		path: fmt.Sprintf("%s/%s/%d/%s/%d", consts.NetworksPath,
 			consts.NetworkRouterPath, routerID, consts.RoutersNatPath, natID),
 		client: r.Client,
 		jsonParser: func(body []byte) error {
@@ -253,7 +247,7 @@ func (r *RouterAPIService) CreateRouterFirewallRuleGroup(
 	routerAPI := &api{
 		compatibleVersion: routerCompatibleVersion,
 		method:            "POST",
-		path: fmt.Sprintf("%s/%s/%s/%s/%d/%s", r.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworksPath,
+		path: fmt.Sprintf("%s/%s/%d/%s", consts.NetworksPath,
 			consts.NetworkRouterPath, routerID, consts.RoutersFirewallRuleGroupPath),
 		client: r.Client,
 		jsonParser: func(body []byte) error {
@@ -273,8 +267,7 @@ func (r *RouterAPIService) GetSpecificRouterFirewallRuleGroup(
 	routerAPI := &api{
 		compatibleVersion: routerCompatibleVersion,
 		method:            "GET",
-		path: fmt.Sprintf("%s/%s/%s/%s/%d/%s/%d",
-			r.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworksPath,
+		path: fmt.Sprintf("%s/%s/%d/%s/%d", consts.NetworksPath,
 			consts.NetworkRouterPath, routerID, consts.RoutersFirewallRuleGroupPath, firewallGroupID),
 		client: r.Client,
 		jsonParser: func(body []byte) error {
@@ -294,9 +287,28 @@ func (r *RouterAPIService) DeleteRouterFirewallRuleGroup(
 	routerAPI := &api{
 		compatibleVersion: routerCompatibleVersion,
 		method:            "DELETE",
-		path: fmt.Sprintf("%s/%s/%s/%s/%d/%s/%d",
-			r.Cfg.Host, consts.VmaasCmpAPIBasePath, consts.NetworksPath,
+		path: fmt.Sprintf("%s/%s/%d/%s/%d", consts.NetworksPath,
 			consts.NetworkRouterPath, routerID, consts.RoutersFirewallRuleGroupPath, firewallGroupID),
+		client: r.Client,
+		jsonParser: func(body []byte) error {
+			return json.Unmarshal(body, &firewallGroupResp)
+		},
+	}
+	err := routerAPI.do(ctx, nil, nil)
+
+	return firewallGroupResp, err
+}
+
+func (r *RouterAPIService) CreateStaticRoute(
+	ctx context.Context,
+	routerID int,
+) (models.SuccessOrErrorMessage, error) {
+	firewallGroupResp := models.SuccessOrErrorMessage{}
+	routerAPI := &api{
+		compatibleVersion: routerCompatibleVersion,
+		method:            "POST",
+		path: fmt.Sprintf("%s/%s/%d", consts.NetworksPath,
+			consts.NetworkRouterPath, routerID),
 		client: r.Client,
 		jsonParser: func(body []byte) error {
 			return json.Unmarshal(body, &firewallGroupResp)

--- a/pkg/client/router_test.go
+++ b/pkg/client/router_test.go
@@ -997,7 +997,7 @@ func TestRouterAPIService_CreateRouterNat(t *testing.T) {
 		name    string
 		args    args
 		given   func(m *MockAPIClientHandler)
-		want    models.CreateRouterNatResponse
+		want    models.SuccessOrErrorMessage
 		wantErr bool
 	}{
 		{
@@ -1039,9 +1039,9 @@ func TestRouterAPIService_CreateRouterNat(t *testing.T) {
 					Body:       respBody,
 				}, nil)
 			},
-			want: models.CreateRouterNatResponse{
-				IDModel:               models.IDModel{ID: 2},
-				SuccessOrErrorMessage: models.SuccessOrErrorMessage{Success: true},
+			want: models.SuccessOrErrorMessage{
+				IDModel: models.IDModel{ID: 2},
+				Success: true,
 			},
 			wantErr: false,
 		},
@@ -1082,7 +1082,7 @@ func TestRouterAPIService_UpdateRouterNat(t *testing.T) {
 		name    string
 		args    args
 		given   func(m *MockAPIClientHandler)
-		want    models.CreateRouterNatResponse
+		want    models.SuccessOrErrorMessage
 		wantErr bool
 	}{
 		{
@@ -1125,10 +1125,8 @@ func TestRouterAPIService_UpdateRouterNat(t *testing.T) {
 					Body:       respBody,
 				}, nil)
 			},
-			want: models.CreateRouterNatResponse{
-				SuccessOrErrorMessage: models.SuccessOrErrorMessage{
-					Success: true,
-				},
+			want: models.SuccessOrErrorMessage{
+				Success: true,
 				IDModel: models.IDModel{
 					ID: 2,
 				},
@@ -1314,7 +1312,7 @@ func TestRouterAPIService_CreateRouterFirewallRuleGroup(t *testing.T) {
 		name    string
 		args    args
 		given   func(m *MockAPIClientHandler)
-		want    models.CreateRouterFirewallRuleGroupResponse
+		want    models.SuccessOrErrorMessage
 		wantErr bool
 	}{
 		{
@@ -1356,9 +1354,9 @@ func TestRouterAPIService_CreateRouterFirewallRuleGroup(t *testing.T) {
 					Body:       respBody,
 				}, nil)
 			},
-			want: models.CreateRouterFirewallRuleGroupResponse{
-				IDModel:               models.IDModel{ID: 2},
-				SuccessOrErrorMessage: models.SuccessOrErrorMessage{Success: true},
+			want: models.SuccessOrErrorMessage{
+				IDModel: models.IDModel{ID: 2},
+				Success: true,
 			},
 			wantErr: false,
 		},

--- a/pkg/client/router_test.go
+++ b/pkg/client/router_test.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"testing"
 
+	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	"github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -37,7 +38,8 @@ func TestRouterAPIService_GetAllRouters(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -76,7 +78,8 @@ func TestRouterAPIService_GetAllRouters(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -94,7 +97,8 @@ func TestRouterAPIService_GetAllRouters(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -163,7 +167,8 @@ func TestRouterAPIService_GetNetworkRouterTypes(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/network-router-types"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/network-router-types"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -202,7 +207,8 @@ func TestRouterAPIService_GetNetworkRouterTypes(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/network-router-types"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/network-router-types"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -220,7 +226,8 @@ func TestRouterAPIService_GetNetworkRouterTypes(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/network-router-types"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/network-router-types"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -288,7 +295,8 @@ func TestRouterAPIService_CreateRouter(t *testing.T) {
 				},
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers"
 				method := "POST"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -364,7 +372,8 @@ func TestRouterAPIService_UpdateRouter(t *testing.T) {
 				},
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers/1"
 				method := "PUT"
 				postBody := ioutil.NopCloser(bytes.NewReader([]byte(`
 				{
@@ -403,7 +412,8 @@ func TestRouterAPIService_UpdateRouter(t *testing.T) {
 				},
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers/1"
 				method := "PUT"
 
 				pBody := models.CreateRouterRequest{
@@ -427,7 +437,8 @@ func TestRouterAPIService_UpdateRouter(t *testing.T) {
 				},
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers/1"
 				method := "PUT"
 				postBody := ioutil.NopCloser(bytes.NewReader([]byte(`
 				{
@@ -500,7 +511,8 @@ func TestRouterAPIService_GetSpecificRouter(t *testing.T) {
 			name:     "Normal Test case 1: Get a specific router",
 			routerID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -529,7 +541,8 @@ func TestRouterAPIService_GetSpecificRouter(t *testing.T) {
 			name:     "Failed Test case 2: Error in prepare request",
 			routerID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -543,7 +556,8 @@ func TestRouterAPIService_GetSpecificRouter(t *testing.T) {
 			name:     "Failed Test case 3: Error in callAPI",
 			routerID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -607,7 +621,8 @@ func TestRouterAPIService_DeleteRouter(t *testing.T) {
 			name:     "Normal Test case 1: Delete a  router",
 			routerID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers/1"
 				method := "DELETE"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -636,7 +651,8 @@ func TestRouterAPIService_DeleteRouter(t *testing.T) {
 			name:     "Failed Test case 2: Error in prepare request",
 			routerID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers/1"
 				method := "DELETE"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -650,7 +666,8 @@ func TestRouterAPIService_DeleteRouter(t *testing.T) {
 			name:     "Failed Test case 3: Error in callAPI",
 			routerID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers/1"
 				method := "DELETE"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -716,7 +733,8 @@ func TestRouterAPIService_GetNetworkServices(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/services"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/services"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -755,7 +773,8 @@ func TestRouterAPIService_GetNetworkServices(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/services"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/services"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -773,7 +792,8 @@ func TestRouterAPIService_GetNetworkServices(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/services"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/services"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -844,7 +864,8 @@ func TestRouterAPIService_DeleteRouterNat(t *testing.T) {
 				natID:    2,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers/1/nats/2"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers/1/nats/2"
 				method := "DELETE"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -912,7 +933,8 @@ func TestRouterAPIService_GetSpecificRouterNat(t *testing.T) {
 				natID:    2,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers/1/nats/2"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers/1/nats/2"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -990,7 +1012,8 @@ func TestRouterAPIService_CreateRouterNat(t *testing.T) {
 				},
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers/1/nats"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers/1/nats"
 				method := "POST"
 				headers := getDefaultHeaders()
 				reqModel := models.CreateRouterNatRequest{
@@ -1075,7 +1098,8 @@ func TestRouterAPIService_UpdateRouterNat(t *testing.T) {
 				},
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers/1/nats/2"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers/1/nats/2"
 				method := "PUT"
 				headers := getDefaultHeaders()
 				reqModel := models.CreateRouterNatRequest{
@@ -1157,7 +1181,8 @@ func TestRouterAPIService_DeleteRouterFirewallRuleGroup(t *testing.T) {
 				firewallGroupID: 2,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers/1/firewall-rule-groups/2"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers/1/firewall-rule-groups/2"
 				method := "DELETE"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -1225,7 +1250,8 @@ func TestRouterAPIService_GetSpecificRouterFirewallRuleGroup(t *testing.T) {
 				firewallGroupID: 2,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers/1/firewall-rule-groups/2"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers/1/firewall-rule-groups/2"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -1303,7 +1329,8 @@ func TestRouterAPIService_CreateRouterFirewallRuleGroup(t *testing.T) {
 				},
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/networks/routers/1/firewall-rule-groups"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/networks/routers/1/firewall-rule-groups"
 				method := "POST"
 				headers := getDefaultHeaders()
 				reqModel := models.CreateRouterFirewallRuleGroupRequest{

--- a/pkg/client/servers.go
+++ b/pkg/client/servers.go
@@ -31,8 +31,7 @@ func (a *ServersAPIService) GetAllServers(
 	serversResponse := models.ServersResponse{}
 	serverAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
-			consts.ServerPath),
+		path:   consts.ServerPath,
 		client: a.Client,
 		jsonParser: func(body []byte) error {
 			return json.Unmarshal(body, &serversResponse)
@@ -49,7 +48,7 @@ func (a *ServersAPIService) GetSpecificServer(
 	serversResponse := models.GetSpecificServerResponse{}
 	serverAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s/%d", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
+		path: fmt.Sprintf("%s/%d",
 			consts.ServerPath, serverID),
 		client: a.Client,
 		jsonParser: func(body []byte) error {

--- a/pkg/client/servers_test.go
+++ b/pkg/client/servers_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"testing"
 
+	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	models "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -36,7 +37,8 @@ func TestServersAPIService_GetAllServers(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/servers"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/servers"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -77,7 +79,8 @@ func TestServersAPIService_GetAllServers(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/servers"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/servers"
 				method := "GET"
 				headers := getDefaultHeaders()
 				m.EXPECT().getVersion().Return(999999)
@@ -95,7 +98,8 @@ func TestServersAPIService_GetAllServers(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/servers"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/servers"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -164,7 +168,8 @@ func TestServersAPIService_GetSpecificServer(t *testing.T) {
 			name:     "Normal Test case 1: Get a specific server",
 			serverID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/servers/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/servers/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -198,7 +203,8 @@ func TestServersAPIService_GetSpecificServer(t *testing.T) {
 			name:     "Failed test case 2: Error in call prepare request",
 			serverID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/servers/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/servers/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				// mock the context only since it is not validated in this function
@@ -213,7 +219,8 @@ func TestServersAPIService_GetSpecificServer(t *testing.T) {
 			name:     "Failed test case 3: error in callAPI",
 			serverID: 1,
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/servers/1"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/servers/1"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -242,6 +249,7 @@ func TestServersAPIService_GetSpecificServer(t *testing.T) {
 			name:     "Failed test case 4: server ID should be greater than 0",
 			serverID: 0,
 			given: func(m *MockAPIClientHandler) {
+				m.EXPECT().getHost().Return(mockHost)
 				m.EXPECT().getVersion().Return(999999)
 			},
 			want:    models.GetSpecificServerResponse{},

--- a/pkg/client/status.go
+++ b/pkg/client/status.go
@@ -18,7 +18,7 @@ type CmpStatus struct {
 func (a *CmpStatus) GetCmpVersion(ctx context.Context) (models.CmpVersionModel, error) {
 	checkResp := models.CmpVersionModel{}
 
-	allCloudDSAPI := &api{
+	statusAPI := &api{
 		method: "GET",
 		path:   consts.WhoamiPath,
 		client: a.Client,
@@ -27,7 +27,7 @@ func (a *CmpStatus) GetCmpVersion(ctx context.Context) (models.CmpVersionModel, 
 			return json.Unmarshal(body, &checkResp)
 		},
 	}
-	err := allCloudDSAPI.do(ctx, nil, nil)
+	err := statusAPI.do(ctx, nil, nil)
 
 	return checkResp, err
 }

--- a/pkg/client/status.go
+++ b/pkg/client/status.go
@@ -5,7 +5,6 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	"github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
@@ -21,8 +20,7 @@ func (a *CmpStatus) GetCmpVersion(ctx context.Context) (models.CmpVersionModel, 
 
 	allCloudDSAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
-			consts.WhoamiPath),
+		path:   consts.WhoamiPath,
 		client: a.Client,
 
 		jsonParser: func(body []byte) error {

--- a/pkg/client/virtual_images.go
+++ b/pkg/client/virtual_images.go
@@ -5,7 +5,6 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	models "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
@@ -31,8 +30,7 @@ func (a *VirtualImagesAPIService) GetAllVirtualImages(ctx context.Context,
 
 	allVirtualImagesAPI := &api{
 		method: "GET",
-		path: fmt.Sprintf("%s/%s/%s", a.Cfg.Host, consts.VmaasCmpAPIBasePath,
-			consts.VirtualImagePath),
+		path:   consts.VirtualImagePath,
 		client: a.Client,
 
 		jsonParser: func(body []byte) error {

--- a/pkg/client/virtual_images_test.go
+++ b/pkg/client/virtual_images_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"testing"
 
+	consts "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/common"
 	models "github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/pkg/models"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -37,7 +38,8 @@ func TestVirtualImagesAPIService_GetAllVirtualImages(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/virtual-images"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/virtual-images"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)
@@ -77,7 +79,8 @@ func TestVirtualImagesAPIService_GetAllVirtualImages(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/virtual-images"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/virtual-images"
 				method := "GET"
 				headers := getDefaultHeaders()
 				// mock the context only since it is not validated in this function
@@ -96,7 +99,8 @@ func TestVirtualImagesAPIService_GetAllVirtualImages(t *testing.T) {
 				"name": templateName,
 			},
 			given: func(m *MockAPIClientHandler) {
-				path := mockHost + "/v1beta1/virtual-images"
+				m.EXPECT().getHost().Return(mockHost)
+				path := mockHost + "/" + consts.VmaasCmpAPIBasePath + "/virtual-images"
 				method := "GET"
 				headers := getDefaultHeaders()
 				req, _ := http.NewRequest(method, path, nil)

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -45,7 +45,9 @@ const (
 	OptionsPath            = "options"
 	ZoneNetworkOptionsPath = "zoneNetworkOptions"
 	ProvisionTypesPath     = "provision-types"
-	WhoamiPath             = "whoami"
+	RouterRoutePath        = "routes"
+
+	WhoamiPath = "whoami"
 
 	// headers
 	ContentType = "application/json"

--- a/pkg/models/generic_responses.go
+++ b/pkg/models/generic_responses.go
@@ -29,6 +29,7 @@ type ErrUnauthorized struct {
 
 // Success Or Failure Message
 type SuccessOrErrorMessage struct {
+	IDModel
 	Success bool        `json:"success,omitempty"`
 	Msg     string      `json:"msg,omitempty"`
 	Message string      `json:"message,omitempty"`

--- a/pkg/models/router.go
+++ b/pkg/models/router.go
@@ -260,14 +260,18 @@ type GetSpecificRouterFirewallRuleGroup struct {
 type CreateRouterRoute struct {
 	NetworkRoute RouterRouteBody `json:"networkRoute"`
 }
+
 type RouterRouteBody struct {
+	ID           int    `json:"-" tf:"id,computed"`
+	RouterID     int    `json:"-" tf:"router_id"`
+	IsDeprecated bool   `json:"-" tf:"is_deprecated,computed"`
 	Name         string `json:"name" tf:"name"`
 	Description  string `json:"description" tf:"description"`
 	Enabled      bool   `json:"enabled" tf:"enabled"`
 	DefaultRoute bool   `json:"defaultRoute" tf:"default_route"`
 	Source       string `json:"source" tf:"network"`
 	Destination  string `json:"destination" tf:"next_hop"`
-	NetworkMtu   string `json:"networkMtu" tf:"mtu"`
+	NetworkMtu   int    `json:"networkMtu" tf:"mtu"`
 	Priority     int    `json:"priority" tf:"priority"`
 }
 

--- a/pkg/models/router.go
+++ b/pkg/models/router.go
@@ -266,3 +266,17 @@ type GetSpecificRouterFirewallRuleGroup struct {
 	GroupLayer   string `json:"groupLayer"`
 	IsDeprecated bool   `json:"-" tf:"is_deprecated,computed"`
 }
+
+type CreateStaticRoute struct {
+	StaticRoute StaticRoute `json:"networkRoute"`
+}
+type StaticRoute struct {
+	Name         string `json:"name" tf:"name"`
+	Description  string `json:"description" tf:"description"`
+	Enabled      bool   `json:"enabled" tf:"enabled"`
+	DefaultRoute bool   `json:"defaultRoute" tf:"default_route"`
+	Source       string `json:"source" tf:"network"`
+	Destination  string `json:"destination" tf:"next_hop"`
+	NetworkMtu   string `json:"networkMtu" tf:"mtu"`
+	Priority     int    `json:"priority" tf:"priority"`
+}

--- a/pkg/models/router.go
+++ b/pkg/models/router.go
@@ -198,11 +198,6 @@ type CreateRouterNatConfig struct {
 	Logging  bool   `json:"logging" tf:"logging"`
 }
 
-type CreateRouterNatResponse struct {
-	IDModel
-	SuccessOrErrorMessage
-}
-
 type GetSpecificRouterNatResponse struct {
 	GetSpecificRouterNat GetSpecificRouterNat `json:"networkRouterNAT"`
 }
@@ -247,11 +242,6 @@ type TfCreateRouterFirewallRuleGroup struct {
 	FirewallRuleGroup []CreateRouterFirewallRuleGroup `tf:"firewall_rule_group"`
 }
 
-type CreateRouterFirewallRuleGroupResponse struct {
-	IDModel
-	SuccessOrErrorMessage
-}
-
 type GetSpecificRouterFirewallRuleGroupResponse struct {
 	GetSpecificRouterFirewallRuleGroup GetSpecificRouterFirewallRuleGroup `json:"ruleGroup"`
 }
@@ -267,10 +257,10 @@ type GetSpecificRouterFirewallRuleGroup struct {
 	IsDeprecated bool   `json:"-" tf:"is_deprecated,computed"`
 }
 
-type CreateStaticRoute struct {
-	StaticRoute StaticRoute `json:"networkRoute"`
+type CreateRouterRoute struct {
+	NetworkRoute RouterRouteBody `json:"networkRoute"`
 }
-type StaticRoute struct {
+type RouterRouteBody struct {
 	Name         string `json:"name" tf:"name"`
 	Description  string `json:"description" tf:"description"`
 	Enabled      bool   `json:"enabled" tf:"enabled"`
@@ -279,4 +269,27 @@ type StaticRoute struct {
 	Destination  string `json:"destination" tf:"next_hop"`
 	NetworkMtu   string `json:"networkMtu" tf:"mtu"`
 	Priority     int    `json:"priority" tf:"priority"`
+}
+
+type GetSpecificRouterRoute struct {
+	NetworkRoute GetSpecificRouterRouteBody `json:"networkRoute"`
+}
+
+type GetSpecificRouterRouteBody struct {
+	ID              int    `json:"id" tf:"id,computed"`
+	Name            string `json:"name"`
+	Code            string `json:"code" tf:"code,computed"`
+	Description     string `json:"description"`
+	Priority        int    `json:"priority"`
+	RouteType       string `json:"routeType" tf:"route_type,computed"`
+	Source          string `json:"source"`
+	SourceType      string `json:"sourceType" tf:"source_type,computed"`
+	Destination     string `json:"destination"`
+	DestinationType string `json:"destinationType"`
+	DefaultRoute    bool   `json:"defaultRoute"`
+	NetworkMtu      int    `json:"networkMtu"`
+	ExternalID      string `json:"externalId" tf:"external_id,computed"`
+	ProviderID      string `json:"providerId" tf:"provider_id,computed"`
+	Enabled         bool   `json:"enabled"`
+	Visible         bool   `json:"visible"`
 }


### PR DESCRIPTION
## Code changes
- Appending host and base URL is moved into `do` function since this is a redundant operation
- Added `id` to `SuccessOrErrorMessage` struct
- Fix UTs
- Added Router route APIs
- UT (TODO)