### PR TITLE
Parse version fix

### DIFF
--- a/pkg/client/helper.go
+++ b/pkg/client/helper.go
@@ -1,4 +1,4 @@
-//  (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 
 package client
 
@@ -77,7 +77,7 @@ func parseVersion(version string) (int, error) {
 	if version == "" {
 		return 0, nil
 	}
-
+	version = strings.Split(version, "-")[0]
 	versionSplit := strings.Split(version, ".")
 
 	mul := 10000


### PR DESCRIPTION
After applying the patch, the version is getting changed
![image](https://github.com/HewlettPackard/hpegl-vmaas-cmp-go-sdk/assets/112473480/c84d987a-f46c-4de8-b6dd-7650ba71b9cf)

This PR is to address it